### PR TITLE
Fix duplicates when selecting apps

### DIFF
--- a/app/src/main/java/com/xequal2/launcher/viewmodel/LauncherViewModel.kt
+++ b/app/src/main/java/com/xequal2/launcher/viewmodel/LauncherViewModel.kt
@@ -34,8 +34,15 @@ class LauncherViewModel(private val context: Context) : ViewModel() {
 
     fun toggleSelection(pkg: String, isChecked: Boolean) {
         AppPrefManager.toggleApp(context, pkg, isChecked)
-        if (isChecked) selectedPackages.add(pkg)
-        else selectedPackages.remove(pkg)
+        if (isChecked) {
+            if (!selectedPackages.contains(pkg)) {
+                selectedPackages.add(pkg)
+            }
+        } else {
+            while (selectedPackages.remove(pkg)) {
+                // remove all duplicates if any exist
+            }
+        }
     }
 
     fun filteredApps(): List<AppItem> {


### PR DESCRIPTION
## Summary
- ensure toggling an app doesn't create duplicate entries

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fcd5d3a248332bc3e5ca95e87ba37